### PR TITLE
fix bug int/size_t

### DIFF
--- a/range.hpp
+++ b/range.hpp
@@ -208,9 +208,17 @@ private:
     iter begin_;
 };
 
+namespace traits{
+    // fix issue int(0) and size_t
+    template <typename T>
+    struct identity {
+        typedef T value_type;
+    };
+}
+
 template <typename T>
 DEVICE_CALLABLE
-range_proxy<T> range(T begin, T end) {
+range_proxy<T> range(T begin, typename traits::identity<T>::value_type end) {
     return {begin, end};
 }
 

--- a/test.cpp
+++ b/test.cpp
@@ -34,4 +34,7 @@ int main() {
 
     for (auto i : indices("foobar").step(2))
         cout << i << '\n';
+
+    for(size_t i:range(0,2))
+        cout << i << '\n';
 }


### PR DESCRIPTION
Hello,

I find a bug (not really I just improve). If you are doing a range like

    std::size_t size(9999);
    for(int i: range(0:size))
         //blablabla

This will not compile as size is uint64_t and 0 is an int. The compiler will complain because there are two type and range use only one.

I fix it using an identity struct from my past experience (http://stackoverflow.com/questions/26705581/operator-and-float-argument)
Some more advance meta-programming may do the job, but I am not template guru.

Free to you to merge it, but at least in my version I fix it.

Best,

Tim

